### PR TITLE
Add option to use a development-only database setup to keep production clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add optional database config
+
 ## 0.3.0
 
 - Add exceptions: Framework + ActiveJob + Sidekiq Worker exceptions.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Eyeloupe.configure do |config|
   config.capture = Rails.env.development?
   config.openai_access_key = "your-openai-access-key"
   config.openai_model = "gpt-4"
+  config.database = 'eyeloupe'
 end
 ```
 
@@ -71,6 +72,19 @@ end
 - `capture` is a boolean to enable/disable Eyeloupe capture. By default, it's set to `true`.
 - `openai_access_key` is the access key to use the OpenAI API. You can get one [here](https://platform.openai.com/).
 - `openai_model` is the model to use for the OpenAI API. You can find the list of available models [here](https://platform.openai.com/docs/models).
+- `database` is an optional database config Eyeloupe will use. This way you can create a secondary database in development to keep your production database clean. Using this you can skip the `eyeloupe:install:migrations` step, but need to setup the database as seen in the example below.
+
+```yml
+development:
+  primary:
+    <<: *default
+    database: db/development.sqlite3
+  eyeloupe:
+    <<: *default
+    database: db/eyeloupe.sqlite3
+    migrations_paths: <%= Gem.loaded_specs['eyeloupe'].full_gem_path + '/db/migrate' %>
+    schema_dump: false
+```
 
 ### Exception handling
 

--- a/app/models/eyeloupe/application_record.rb
+++ b/app/models/eyeloupe/application_record.rb
@@ -1,5 +1,9 @@
 module Eyeloupe
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true
+
+    if Eyeloupe.configuration.database
+      connects_to database: { writing: Eyeloupe.configuration.database.to_sym, reading: Eyeloupe.configuration.database.to_sym }
+    end
   end
 end

--- a/lib/eyeloupe/configuration.rb
+++ b/lib/eyeloupe/configuration.rb
@@ -5,6 +5,9 @@ module Eyeloupe
   class Configuration
     include Singleton
 
+    # @return [Symbol|Nil]
+    attr_accessor :database
+
     # @return [Array<String>]
     attr_accessor :excluded_paths
 


### PR DESCRIPTION
Hi. Thanks for the project, it looks very promising :)

I had one small issue, which is I don't really want to add this to production, just as I'm not including debug / byebug in prod, I have other tools to monitor what's going on the servers.

Then I had an idea to solve this: we can use [multiple databases](https://guides.rubyonrails.org/active_record_multiple_databases.html) supported by Rails 7, which is the minimum requirement for the gem already. I added an optional config to keep Eyeloupe in a secondary database without any extra hassle with migrations or schema files.

Let me know if you like this idea or if there's anything I need to add to this PR